### PR TITLE
Fix for empty directories

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -25,7 +25,7 @@ function unwrapResponse(prefix, node) {
     return key.replace(new RegExp("/?" + prefix + "/?"), "");
   }
 
-  node.nodes.forEach(function (n) {
+  !!node.nodes && node.nodes.forEach(function (n) {
     result[keyWithoutPrefix(n.key)] = unwrapResponse(n.key, n);
   });
 


### PR DESCRIPTION
When a empty directory is present the unwrapping fails. Returning result as "{}" should be enough. 
